### PR TITLE
POC: Call bytecode transformer

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -31,9 +31,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.8.1</version>
                 <configuration>
                     <annotationProcessorPaths>
+                        <annotationProcessorPath>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.12</version>
+                        </annotationProcessorPath>
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>

--- a/api/src/main/java/net/rsmogura/picoson/abi/Names.java
+++ b/api/src/main/java/net/rsmogura/picoson/abi/Names.java
@@ -36,16 +36,16 @@ public final class Names {
    * However, this method is used in "standard" situation when
    * class hierarchy has to maintained.
    */
-  public static final String INSTANCE_DESERIALIZE_METHOD_NAME = "$jsonRead";
+  public static final String INSTANCE_DESERIALIZE_METHOD_NAME = "#jsonRead";
 
-  public static final String READ_PROPERTY_NAME = "$jsonReadProp";
+  public static final String READ_PROPERTY_NAME = "#jsonReadProp";
 
   /** The default name of method used to convert object to map. */
   public static final String GENERATED_TO_MAP_METHOD = "toMap";
 
   /** Method used to initialize properties statically. */
-  public static final String DESCRIPTOR_INITIALIZER = "$jsonInitDesc";
+  public static final String DESCRIPTOR_INITIALIZER = "#jsonInitDesc";
 
   /** Filed holding object descriptor. */
-  public static final String DESCRIPTOR_HOLDER = "$jsonDesc";
+  public static final String DESCRIPTOR_HOLDER = "#jsonDesc";
 }

--- a/generator-core/pom.xml
+++ b/generator-core/pom.xml
@@ -33,8 +33,8 @@
     <dependencies>
         <dependency>
             <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-all</artifactId>
-            <version>5.2</version>
+            <artifactId>asm</artifactId>
+            <version>8.0.1</version>
         </dependency>
         <dependency>
             <groupId>net.rsmogura.picoson</groupId>

--- a/generator-core/src/main/java/net/rsmogura/picoson/generator/core/PicosonGeneratorException.java
+++ b/generator-core/src/main/java/net/rsmogura/picoson/generator/core/PicosonGeneratorException.java
@@ -15,29 +15,20 @@
 
 package net.rsmogura.picoson.generator.core;
 
-import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.MethodVisitor;
+/**
+ * Thrown during generation or transformation of JSON classes.
+ */
+public class PicosonGeneratorException extends RuntimeException {
 
-import static net.rsmogura.picoson.abi.Names.INSTANCE_DESERIALIZE_METHOD_NAME;
-
-public class ReaderMethodGenerator extends ClassVisitor {
-
-  public ReaderMethodGenerator(int i, ClassVisitor classVisitor) {
-    super(i, classVisitor);
+  public PicosonGeneratorException(String message) {
+    super(message);
   }
 
-  @Override
-  public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
-    if (!INSTANCE_DESERIALIZE_METHOD_NAME.equals(name)) {
-      return super.visitMethod(access, name, desc, signature, exceptions);
-    } else {
-      // Don't visit this method it will be re-generated
-      return null;
-    }
+  public PicosonGeneratorException(String message, Throwable cause) {
+    super(message, cause);
   }
 
-  @Override
-  public void visitEnd() {
-    super.visitEnd();
+  public PicosonGeneratorException(Throwable cause) {
+    super(cause);
   }
 }

--- a/generator-core/src/main/java/net/rsmogura/picoson/generator/core/PicosonJavacClassTransformer.java
+++ b/generator-core/src/main/java/net/rsmogura/picoson/generator/core/PicosonJavacClassTransformer.java
@@ -15,34 +15,37 @@
 
 package net.rsmogura.picoson.generator.core;
 
+import net.rsmogura.picoson.abi.Names;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.Opcodes;
 
-public class ClassAnalyzer extends ClassVisitor {
-  public ClassAnalyzer(int api, ClassVisitor cv) {
+/**
+ * Class transformer supporting JavaC ATP.
+ * <br />
+ * Even using JavaC API ATP has some limitations, this transformer
+ * can help overcome this limitations.
+ */
+public class PicosonJavacClassTransformer extends ClassVisitor {
+  public PicosonJavacClassTransformer(int api, ClassVisitor cv) {
     super(api, cv);
   }
 
   @Override
-  public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
+  public FieldVisitor visitField(int access, String name, String desc,
+                                 String signature, Object value) {
+    if (Names.DESCRIPTOR_HOLDER.equals(name)) {
+      // Override synthetic
+      access = access | Opcodes.ACC_SYNTHETIC;
+    }
+
     FieldVisitor fieldVisitor = super.visitField(access, name, desc, signature, value);
-    return new FieldAnalyzer(this.api, fieldVisitor);
+    return fieldVisitor;
   }
 
   @Override
   public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
     return super.visitAnnotation(desc, visible);
-  }
-
-  protected class FieldAnalyzer extends FieldVisitor {
-    public FieldAnalyzer(int api, FieldVisitor fv) {
-      super(api, fv);
-    }
-
-    @Override
-    public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
-      return super.visitAnnotation(desc, visible);
-    }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,13 @@
             <artifactId>guava</artifactId>
             <version>29.0-jre</version>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>3.5.10</version>
+            <scope>test</scope>
+        </dependency>
+
 
     </dependencies>
 </project>

--- a/processor-core/pom.xml
+++ b/processor-core/pom.xml
@@ -61,5 +61,22 @@
             <artifactId>api</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>net.rsmogura.picoson</groupId>
+            <artifactId>generator-core</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.5.10</version>
+        </dependency>
+
     </dependencies>
 </project>

--- a/processor-core/src/main/java/net/rsmogura/picoson/processor/AnnotationProcessor.java
+++ b/processor-core/src/main/java/net/rsmogura/picoson/processor/AnnotationProcessor.java
@@ -15,6 +15,10 @@
 
 package net.rsmogura.picoson.processor;
 
+import com.sun.source.util.JavacTask;
+import com.sun.source.util.TaskEvent;
+import com.sun.source.util.TaskEvent.Kind;
+import com.sun.source.util.TaskListener;
 import com.sun.tools.javac.processing.JavacProcessingEnvironment;
 import java.util.Set;
 import javax.annotation.processing.AbstractProcessor;
@@ -38,5 +42,18 @@ public class AnnotationProcessor extends AbstractProcessor {
         .getElementsAnnotatedWith(Json.class)
         .forEach(e -> new ReaderMethodGenerator(javacProcessingEnv).createReaderMethod(e));
     return true;
+  }
+
+  protected void addClassTransformationHandlers() {
+    final JavacTask currentTask = JavacTask.instance(this.processingEnv);
+    currentTask.addTaskListener(
+        new TaskListener() {
+          @Override
+          public void finished(TaskEvent e) {
+            if (e.getKind() == Kind.COMPILATION) {
+              System.out.println("Finished compilation");
+            }
+          }
+        });
   }
 }

--- a/processor-core/src/main/java/net/rsmogura/picoson/processor/PicosonTransformJavacTaskListener.java
+++ b/processor-core/src/main/java/net/rsmogura/picoson/processor/PicosonTransformJavacTaskListener.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.rsmogura.picoson.processor;
+
+import com.sun.source.util.TaskEvent;
+import com.sun.source.util.TaskListener;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import javax.tools.JavaFileManager;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardLocation;
+import net.rsmogura.picoson.generator.core.PicosonGeneratorException;
+import net.rsmogura.picoson.generator.core.PicosonJavacClassTransformer;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+
+/** Initiates transform of single JSON. */
+class PicosonTransformJavacTaskListener implements TaskListener {
+  private final JavaFileManager fileManager;
+
+  public PicosonTransformJavacTaskListener(JavaFileManager fileManager) {
+    this.fileManager = fileManager;
+  }
+
+  @Override
+  public void finished(TaskEvent e) {
+    if (e.getKind() == TaskEvent.Kind.GENERATE) {
+      try {
+        transformClass(e, fileManager);
+      } catch (PicosonGeneratorException pex) {
+        throw pex;
+      } catch (Exception ex) {
+        throw new PicosonGeneratorException(ex);
+      }
+    }
+  }
+
+  /** Transform class basing on event. Extracts output file object basing on event. */
+  protected void transformClass(TaskEvent e, JavaFileManager fileManager) throws IOException {
+    // TODO Add tests for inner classes
+
+    JavaFileObject javaClassFile =
+        fileManager.getJavaFileForOutput(
+            StandardLocation.CLASS_OUTPUT,
+            // TODO Flat name (inner classes)
+            e.getTypeElement().getQualifiedName().toString(),
+            JavaFileObject.Kind.CLASS,
+            e.getSourceFile());
+
+    try (InputStream classIn = javaClassFile.openInputStream()) {
+      ClassReader classReader = new ClassReader(classIn);
+      ClassWriter classWriter =
+          new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
+      PicosonJavacClassTransformer picosonJavacClassTransformer =
+          new PicosonJavacClassTransformer(Opcodes.ASM5, classWriter);
+      classReader.accept(picosonJavacClassTransformer, 0);
+
+      try (OutputStream out = javaClassFile.openOutputStream()) {
+        out.write(classWriter.toByteArray());
+      }
+    }
+  }
+}

--- a/processor-core/src/main/java/net/rsmogura/picoson/processor/javac/JsonObjectDescriptorGenerator.java
+++ b/processor-core/src/main/java/net/rsmogura/picoson/processor/javac/JsonObjectDescriptorGenerator.java
@@ -72,7 +72,7 @@ public class JsonObjectDescriptorGenerator extends AbstractJavacGenerator {
 
     // Create symbol describing variable
     VarSymbol sym = new VarSymbol(
-        Flags.STATIC | Flags.FINAL | Flags.PUBLIC | Flags.SYNTHETIC,
+        Flags.STATIC | Flags.FINAL | Flags.PUBLIC,
         names.fromString(Names.DESCRIPTOR_HOLDER),
         elements.getTypeElement(JsonObjectDescriptor.class.getCanonicalName()).type,
         ctx.getProcessedClass().sym

--- a/processor-core/src/main/java/net/rsmogura/picoson/processor/javac/ReadUtils.java
+++ b/processor-core/src/main/java/net/rsmogura/picoson/processor/javac/ReadUtils.java
@@ -33,7 +33,7 @@ public class ReadUtils extends AbstractJavacGenerator {
   }
 
   /**
-   * Builds tree to call JsonReader no arg methods
+   * Builds tree to call JsonReader no arg methods.
    */
   protected JCExpression callJsonReaderMethod(Name readerVar, String methodName) {
     return treeMaker.Apply(

--- a/processor-core/src/test/java/net/rsmogura/picoson/processor/AnnotationProcessorTest.java
+++ b/processor-core/src/test/java/net/rsmogura/picoson/processor/AnnotationProcessorTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.rsmogura.picoson.processor;
+
+import com.sun.source.util.JavacTask;
+import com.sun.tools.javac.processing.JavacProcessingEnvironment;
+import com.sun.tools.javac.util.Context;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.tools.JavaFileManager;
+
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AnnotationProcessorTest {
+
+  @Spy
+  AnnotationProcessor annotationProcessor = new AnnotationProcessor();
+
+  @Mock
+  JavacProcessingEnvironment javacProcessingEnvironment;
+
+  @Mock
+  Context javacContext;
+
+  @Mock
+  JavacTask javacTask;
+
+  @Mock
+  JavaFileManager javaFileManager;
+
+  @BeforeEach
+  void beforeEach() {
+    when(javacProcessingEnvironment.getContext()).thenReturn(javacContext);
+    when(javacContext.get(JavacTask.class)).thenReturn(javacTask);
+    when(javacContext.get(JavaFileManager.class)).thenReturn(javaFileManager);
+
+  }
+  @Test
+  void init() {
+    annotationProcessor.init(javacProcessingEnvironment);
+
+    doNothing().when(annotationProcessor).addClassTransformationHandlers(same(javacProcessingEnvironment));
+    verify(annotationProcessor).addClassTransformationHandlers(same(javacProcessingEnvironment));
+  }
+
+  @Test
+  void addClassTransformationHandlers() {
+    annotationProcessor.addClassTransformationHandlers(javacProcessingEnvironment);
+    verify(javacTask).addTaskListener(any(PicosonTransformJavacTaskListener.class));
+  }
+}


### PR DESCRIPTION
This is experimental commit to integrate byte code transformer
with ATP.

Using bytecode transformer can be beneficial over JavaC API, as
such transformer can be used to transform already generated classes.

However coexistence of both can be hard - and functionality slightly
differs. I.e.
- javac API it's easier to describe types;
- javac API can't use synthetic methods, while bytecode transformer
  will allow it.

Generally, using byte code transformer can be more beneficial as it
can be used for transforming already generated classes.
As both ways are POC nothing is determined now, and both approaches
will be developed.