### PR TITLE
Write support

### DIFF
--- a/api/src/main/java/net/rsmogura/picoson/JsonReader.java
+++ b/api/src/main/java/net/rsmogura/picoson/JsonReader.java
@@ -94,7 +94,12 @@ public class JsonReader {
 
   public String nextString() {
     try {
-      return gsonReader.nextString();
+      if (gsonReader.peek() == JsonToken.NULL) {
+        gsonReader.nextNull();
+        return null;
+      } else {
+        return gsonReader.nextString();
+      }
     } catch (IOException e) {
       throw new JsonReadException(e);
     }

--- a/api/src/main/java/net/rsmogura/picoson/JsonWriteException.java
+++ b/api/src/main/java/net/rsmogura/picoson/JsonWriteException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.rsmogura.picoson;
+
+/**
+ * Thrown during issues with writing JSON.
+ */
+public class JsonWriteException extends RuntimeException {
+
+  public JsonWriteException() {
+  }
+
+  public JsonWriteException(String message) {
+    super(message);
+  }
+
+  public JsonWriteException(Throwable cause) {
+    super(cause);
+  }
+
+  public JsonWriteException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/api/src/main/java/net/rsmogura/picoson/JsonWriteException.java
+++ b/api/src/main/java/net/rsmogura/picoson/JsonWriteException.java
@@ -16,7 +16,7 @@
 package net.rsmogura.picoson;
 
 /**
- * Thrown during issues with writing JSON.
+ * Thrown when some kind of issue during writing of JSON occurred.
  */
 public class JsonWriteException extends RuntimeException {
 

--- a/api/src/main/java/net/rsmogura/picoson/JsonWriter.java
+++ b/api/src/main/java/net/rsmogura/picoson/JsonWriter.java
@@ -21,7 +21,7 @@ import java.io.Writer;
 /**
  * Used to write JSON to output {@link java.io.Writer}
  */
-public class JsonWriter {
+public class JsonWriter implements AutoCloseable {
   private final net.rsmogura.picoson.gson.JsonWriter jsonWriter;
 
   protected JsonWriter(net.rsmogura.picoson.gson.JsonWriter jsonWriter) {

--- a/api/src/main/java/net/rsmogura/picoson/JsonWriter.java
+++ b/api/src/main/java/net/rsmogura/picoson/JsonWriter.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.rsmogura.picoson;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * Used to write JSON to output {@link java.io.Writer}
+ */
+public class JsonWriter {
+  private final net.rsmogura.picoson.gson.JsonWriter jsonWriter;
+
+  protected JsonWriter(net.rsmogura.picoson.gson.JsonWriter jsonWriter) {
+    this.jsonWriter = jsonWriter;
+  }
+
+  public JsonWriter(Writer writer) {
+    this.jsonWriter = new net.rsmogura.picoson.gson.JsonWriter(writer);
+  }
+
+  public JsonWriter beginArray() throws IOException {
+    try {
+      jsonWriter.beginArray();
+      return this;
+    } catch (IOException ioe) {
+      throw new JsonWriteException(ioe);
+    }
+  }
+
+  public JsonWriter endArray() {
+    try {
+      jsonWriter.endArray();
+      return this;
+    } catch (IOException e) {
+      throw new JsonWriteException(e);
+    }
+  }
+
+  public JsonWriter beginObject() {
+    try {
+      jsonWriter.beginObject();
+      return this;
+    } catch (IOException e) {
+      throw new JsonWriteException(e);
+    }
+  }
+
+  public JsonWriter endObject() {
+    try {
+      jsonWriter.endObject();
+      return this;
+    } catch (IOException e) {
+      throw new JsonWriteException(e);
+    }
+  }
+
+  public JsonWriter name(String name) {
+    try {
+      jsonWriter.name(name);
+      return this;
+    } catch (IOException e) {
+      throw new JsonWriteException(e);
+    }
+  }
+
+  public JsonWriter value(String value) {
+    try {
+      jsonWriter.value(value);
+      return this;
+    } catch (IOException e) {
+      throw new JsonWriteException(e);
+    }
+  }
+
+  public JsonWriter jsonValue(String value) {
+    try {
+      jsonWriter.value(value);
+      return this;
+    } catch (IOException e) {
+      throw new JsonWriteException(e);
+    }
+  }
+
+  public JsonWriter nullValue() {
+    try {
+      jsonWriter.nullValue();
+      return this;
+    } catch (IOException e) {
+      throw new JsonWriteException(e);
+    }
+  }
+
+  public JsonWriter value(boolean value) {
+    try {
+      jsonWriter.value(value);
+      return this;
+    } catch (IOException e) {
+      throw new JsonWriteException(e);
+    }
+  }
+
+  public JsonWriter value(Boolean value) {
+    try {
+      jsonWriter.value(value);
+      return this;
+    } catch (IOException e) {
+      throw new JsonWriteException(e);
+    }
+  }
+
+  public JsonWriter value(double value) {
+    try {
+      jsonWriter.value(value);
+      return this;
+    } catch (IOException e) {
+      throw new JsonWriteException(e);
+    }
+  }
+
+  public JsonWriter value(long value) {
+    try {
+      jsonWriter.value(value);
+      return this;
+    } catch (IOException e) {
+      throw new JsonWriteException(e);
+    }
+  }
+
+  public void value(Number value) {
+    try {
+      jsonWriter.value(value);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public void flush() {
+    try {
+      jsonWriter.flush();
+    } catch (IOException e) {
+      throw new JsonWriteException(e);
+    }
+  }
+
+  public void close() {
+    try {
+      jsonWriter.close();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/api/src/main/java/net/rsmogura/picoson/JsonWriter.java
+++ b/api/src/main/java/net/rsmogura/picoson/JsonWriter.java
@@ -144,7 +144,7 @@ public class JsonWriter implements AutoCloseable {
     try {
       jsonWriter.value(value);
     } catch (IOException e) {
-      e.printStackTrace();
+      throw new JsonWriteException(e);
     }
   }
 
@@ -160,7 +160,7 @@ public class JsonWriter implements AutoCloseable {
     try {
       jsonWriter.close();
     } catch (IOException e) {
-      e.printStackTrace();
+      throw new JsonWriteException(e);
     }
   }
 }

--- a/api/src/main/java/net/rsmogura/picoson/JsonWriter.java
+++ b/api/src/main/java/net/rsmogura/picoson/JsonWriter.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 import java.io.Writer;
 
 /**
- * Used to write JSON to output {@link java.io.Writer}
+ * Provides low-level support for writing JSON.
  */
 public class JsonWriter implements AutoCloseable {
   private final net.rsmogura.picoson.gson.JsonWriter jsonWriter;

--- a/api/src/main/java/net/rsmogura/picoson/abi/JsonObjectDescriptor.java
+++ b/api/src/main/java/net/rsmogura/picoson/abi/JsonObjectDescriptor.java
@@ -15,6 +15,9 @@
 
 package net.rsmogura.picoson.abi;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import lombok.Value;
 
@@ -36,6 +39,8 @@ public final class JsonObjectDescriptor {
   /** Maps internal property name to descriptor. */
   private final Map<String, JsonPropertyDescriptor> internalProperties;
 
+  private final List<JsonPropertyDescriptor> properties;
+
   public JsonObjectDescriptor(Class<?> jsonClass,
       JsonObjectDescriptor superDescriptor,
       Map<String, JsonPropertyDescriptor> jsonProperties,
@@ -45,5 +50,13 @@ public final class JsonObjectDescriptor {
     this.superDescriptor = superDescriptor;
     this.jsonProperties = jsonProperties;
     this.internalProperties = internalProperties;
+
+    // Keeping this here instead of returning jsonProperties.values()
+    // increases throughput by 50%
+    this.properties = new ArrayList<>(jsonProperties.values());
+  }
+
+  public Collection<JsonPropertyDescriptor> getProperties() {
+    return properties;
   }
 }

--- a/api/src/main/java/net/rsmogura/picoson/abi/JsonObjectDescriptor.java
+++ b/api/src/main/java/net/rsmogura/picoson/abi/JsonObjectDescriptor.java
@@ -16,8 +16,6 @@
 package net.rsmogura.picoson.abi;
 
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import lombok.Value;
 
@@ -39,7 +37,7 @@ public final class JsonObjectDescriptor {
   /** Maps internal property name to descriptor. */
   private final Map<String, JsonPropertyDescriptor> internalProperties;
 
-  private final List<JsonPropertyDescriptor> properties;
+  private final JsonPropertyDescriptor[] properties;
 
   public JsonObjectDescriptor(Class<?> jsonClass,
       JsonObjectDescriptor superDescriptor,
@@ -51,12 +49,10 @@ public final class JsonObjectDescriptor {
     this.jsonProperties = jsonProperties;
     this.internalProperties = internalProperties;
 
-    // Keeping this here instead of returning jsonProperties.values()
-    // increases throughput by 50%
-    this.properties = new ArrayList<>(jsonProperties.values());
-  }
-
-  public Collection<JsonPropertyDescriptor> getProperties() {
-    return properties;
+    // Keeping this here instead of returning jsonProperties.values() in
+    // `getProperties` increases throughput by 50%, and using array instead of list by
+    // additional 5-10%
+    final JsonPropertyDescriptor[] descriptors = new JsonPropertyDescriptor[jsonProperties.size()];
+    this.properties = new ArrayList<>(jsonProperties.values()).toArray(descriptors);
   }
 }

--- a/api/src/main/java/net/rsmogura/picoson/abi/Names.java
+++ b/api/src/main/java/net/rsmogura/picoson/abi/Names.java
@@ -26,18 +26,30 @@ public final class Names {
 
   }
 
-  /** The name of synthetic method used to read JSON. */
+  /**
+   * The name of method used to read JSON. This method is public, and it can
+   * be used from user-code (as the entry point to deserialize given
+   * class). This method is optional.
+   */
   public static final String GENERATED_DESERIALIZE_METHOD_NAME = "jsonRead";
 
-  /** The name of internal deserialize method. This is instance method
-   * and it may not be always present (i.e. in situations when builders
-   * or constructor params are used).
+  /**
+   * The name of internal, synthetic deserialize method. This is a static method
+   * and it's typically responsible for setting up class instance and fields.
    * <br />
-   * However, this method is used in "standard" situation when
-   * class hierarchy has to be maintained.
+   * This method is part of ABI (Internal API).
    */
   public static final String INSTANCE_DESERIALIZE_METHOD_NAME = "#jsonRead";
 
+  /**
+   * The name of internal, synthetic method to deserialize single property and set
+   * the corresponding field / property in object.
+   * This method is typically called from {@link #INSTANCE_DESERIALIZE_METHOD_NAME}.
+   * <br />
+   * This method is part of ABI.
+   * <br />
+   * This method may not always be present in the class.
+   */
   public static final String READ_PROPERTY_NAME = "#jsonReadProp";
 
   /**
@@ -48,22 +60,31 @@ public final class Names {
 
   /**
    * Name of public method which can be used to serialize instance.
-   * This method may not always be present.
+   * This method may not always be present, typically calls
+   * {@link #INSTANCE_SERIALIZE_METHOD_NAME}.
    */
   public static final String INSTANCE_SERIALIZE_PUBLIC_METHOD = "jsonWrite";
 
   /**
    * Name of internal method used to write property.
-   * It is not part of ABI or public API.
+   * <br />
+   * It is part of ABI.
+   * @see #READ_PROPERTY_NAME
    */
   public static final String WRITE_PROPERTY_NAME = "#jsonWriteProp";
 
   /** The default name of method used to convert object to map. */
   public static final String GENERATED_TO_MAP_METHOD = "toMap";
 
-  /** Method used to initialize properties statically. */
+  /**
+   * Method used to initialize object and property descriptors,
+   * for a given class. It's static synthetic method.
+   */
   public static final String DESCRIPTOR_INITIALIZER = "#jsonInitDesc";
 
-  /** Filed holding object descriptor. */
+  /**
+   * Filed holding object descriptor. This field is typically initialized
+   * by {@link #DESCRIPTOR_INITIALIZER}.
+   */
   public static final String DESCRIPTOR_HOLDER = "#jsonDesc";
 }

--- a/api/src/main/java/net/rsmogura/picoson/abi/Names.java
+++ b/api/src/main/java/net/rsmogura/picoson/abi/Names.java
@@ -30,15 +30,33 @@ public final class Names {
   public static final String GENERATED_DESERIALIZE_METHOD_NAME = "jsonRead";
 
   /** The name of internal deserialize method. This is instance method
-   * and it may be always present (i.e. in situations when builders
+   * and it may not be always present (i.e. in situations when builders
    * or constructor params are used).
    * <br />
    * However, this method is used in "standard" situation when
-   * class hierarchy has to maintained.
+   * class hierarchy has to be maintained.
    */
   public static final String INSTANCE_DESERIALIZE_METHOD_NAME = "#jsonRead";
 
   public static final String READ_PROPERTY_NAME = "#jsonReadProp";
+
+  /**
+   * The name of internal serialize method.
+   * <b>It's part of ABI (Internal API).</b>
+   */
+  public static final String INSTANCE_SERIALIZE_METHOD_NAME = "#jsonWrite";
+
+  /**
+   * Name of public method which can be used to serialize instance.
+   * This method may not always be present.
+   */
+  public static final String INSTANCE_SERIALIZE_PUBLIC_METHOD = "jsonWrite";
+
+  /**
+   * Name of internal method used to write property.
+   * It is not part of ABI or public API.
+   */
+  public static final String WRITE_PROPERTY_NAME = "#jsonWriteProp";
 
   /** The default name of method used to convert object to map. */
   public static final String GENERATED_TO_MAP_METHOD = "toMap";

--- a/api/src/main/java/net/rsmogura/picoson/gson/JsonWriter.java
+++ b/api/src/main/java/net/rsmogura/picoson/gson/JsonWriter.java
@@ -1,0 +1,658 @@
+/*
+ * Copyright (C) 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.rsmogura.picoson.gson;
+
+import java.io.Closeable;
+import java.io.Flushable;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Arrays;
+
+import static net.rsmogura.picoson.gson.JsonScope.DANGLING_NAME;
+import static net.rsmogura.picoson.gson.JsonScope.EMPTY_ARRAY;
+import static net.rsmogura.picoson.gson.JsonScope.EMPTY_DOCUMENT;
+import static net.rsmogura.picoson.gson.JsonScope.EMPTY_OBJECT;
+import static net.rsmogura.picoson.gson.JsonScope.NONEMPTY_ARRAY;
+import static net.rsmogura.picoson.gson.JsonScope.NONEMPTY_DOCUMENT;
+import static net.rsmogura.picoson.gson.JsonScope.NONEMPTY_OBJECT;
+
+/**
+ * Writes a JSON (<a href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>)
+ * encoded value to a stream, one token at a time. The stream includes both
+ * literal values (strings, numbers, booleans and nulls) as well as the begin
+ * and end delimiters of objects and arrays.
+ *
+ * <h3>Encoding JSON</h3>
+ * To encode your data as JSON, create a new {@code JsonWriter}. Each JSON
+ * document must contain one top-level array or object. Call methods on the
+ * writer as you walk the structure's contents, nesting arrays and objects as
+ * necessary:
+ * <ul>
+ *   <li>To write <strong>arrays</strong>, first call {@link #beginArray()}.
+ *       Write each of the array's elements with the appropriate {@link #value}
+ *       methods or by nesting other arrays and objects. Finally close the array
+ *       using {@link #endArray()}.
+ *   <li>To write <strong>objects</strong>, first call {@link #beginObject()}.
+ *       Write each of the object's properties by alternating calls to
+ *       {@link #name} with the property's value. Write property values with the
+ *       appropriate {@link #value} method or by nesting other objects or arrays.
+ *       Finally close the object using {@link #endObject()}.
+ * </ul>
+ *
+ * <h3>Example</h3>
+ * Suppose we'd like to encode a stream of messages such as the following: <pre> {@code
+ * [
+ *   {
+ *     "id": 912345678901,
+ *     "text": "How do I stream JSON in Java?",
+ *     "geo": null,
+ *     "user": {
+ *       "name": "json_newb",
+ *       "followers_count": 41
+ *      }
+ *   },
+ *   {
+ *     "id": 912345678902,
+ *     "text": "@json_newb just use JsonWriter!",
+ *     "geo": [50.454722, -104.606667],
+ *     "user": {
+ *       "name": "jesse",
+ *       "followers_count": 2
+ *     }
+ *   }
+ * ]}</pre>
+ * This code encodes the above structure: <pre>   {@code
+ *   public void writeJsonStream(OutputStream out, List<Message> messages) throws IOException {
+ *     JsonWriter writer = new JsonWriter(new OutputStreamWriter(out, "UTF-8"));
+ *     writer.setIndent("    ");
+ *     writeMessagesArray(writer, messages);
+ *     writer.close();
+ *   }
+ *
+ *   public void writeMessagesArray(JsonWriter writer, List<Message> messages) throws IOException {
+ *     writer.beginArray();
+ *     for (Message message : messages) {
+ *       writeMessage(writer, message);
+ *     }
+ *     writer.endArray();
+ *   }
+ *
+ *   public void writeMessage(JsonWriter writer, Message message) throws IOException {
+ *     writer.beginObject();
+ *     writer.name("id").value(message.getId());
+ *     writer.name("text").value(message.getText());
+ *     if (message.getGeo() != null) {
+ *       writer.name("geo");
+ *       writeDoublesArray(writer, message.getGeo());
+ *     } else {
+ *       writer.name("geo").nullValue();
+ *     }
+ *     writer.name("user");
+ *     writeUser(writer, message.getUser());
+ *     writer.endObject();
+ *   }
+ *
+ *   public void writeUser(JsonWriter writer, User user) throws IOException {
+ *     writer.beginObject();
+ *     writer.name("name").value(user.getName());
+ *     writer.name("followers_count").value(user.getFollowersCount());
+ *     writer.endObject();
+ *   }
+ *
+ *   public void writeDoublesArray(JsonWriter writer, List<Double> doubles) throws IOException {
+ *     writer.beginArray();
+ *     for (Double value : doubles) {
+ *       writer.value(value);
+ *     }
+ *     writer.endArray();
+ *   }}</pre>
+ *
+ * <p>Each {@code JsonWriter} may be used to write a single JSON stream.
+ * Instances of this class are not thread safe. Calls that would result in a
+ * malformed JSON string will fail with an {@link IllegalStateException}.
+ *
+ * @author Jesse Wilson
+ * @since 1.6
+ */
+public class JsonWriter implements Closeable, Flushable {
+
+  /*
+   * From RFC 7159, "All Unicode characters may be placed within the
+   * quotation marks except for the characters that must be escaped:
+   * quotation mark, reverse solidus, and the control characters
+   * (U+0000 through U+001F)."
+   *
+   * We also escape '\u2028' and '\u2029', which JavaScript interprets as
+   * newline characters. This prevents eval() from failing with a syntax
+   * error. http://code.google.com/p/google-gson/issues/detail?id=341
+   */
+  private static final String[] REPLACEMENT_CHARS;
+  private static final String[] HTML_SAFE_REPLACEMENT_CHARS;
+  static {
+    REPLACEMENT_CHARS = new String[128];
+    for (int i = 0; i <= 0x1f; i++) {
+      REPLACEMENT_CHARS[i] = String.format("\\u%04x", (int) i);
+    }
+    REPLACEMENT_CHARS['"'] = "\\\"";
+    REPLACEMENT_CHARS['\\'] = "\\\\";
+    REPLACEMENT_CHARS['\t'] = "\\t";
+    REPLACEMENT_CHARS['\b'] = "\\b";
+    REPLACEMENT_CHARS['\n'] = "\\n";
+    REPLACEMENT_CHARS['\r'] = "\\r";
+    REPLACEMENT_CHARS['\f'] = "\\f";
+    HTML_SAFE_REPLACEMENT_CHARS = REPLACEMENT_CHARS.clone();
+    HTML_SAFE_REPLACEMENT_CHARS['<'] = "\\u003c";
+    HTML_SAFE_REPLACEMENT_CHARS['>'] = "\\u003e";
+    HTML_SAFE_REPLACEMENT_CHARS['&'] = "\\u0026";
+    HTML_SAFE_REPLACEMENT_CHARS['='] = "\\u003d";
+    HTML_SAFE_REPLACEMENT_CHARS['\''] = "\\u0027";
+  }
+
+  /** The output data, containing at most one top-level array or object. */
+  private final Writer out;
+
+  private int[] stack = new int[32];
+  private int stackSize = 0;
+  {
+    push(EMPTY_DOCUMENT);
+  }
+
+  /**
+   * A string containing a full set of spaces for a single level of
+   * indentation, or null for no pretty printing.
+   */
+  private String indent;
+
+  /**
+   * The name/value separator; either ":" or ": ".
+   */
+  private String separator = ":";
+
+  private boolean lenient;
+
+  private boolean htmlSafe;
+
+  private String deferredName;
+
+  private boolean serializeNulls = true;
+
+  /**
+   * Creates a new instance that writes a JSON-encoded stream to {@code out}.
+   * For best performance, ensure {@link Writer} is buffered; wrapping in
+   * {@link java.io.BufferedWriter BufferedWriter} if necessary.
+   */
+  public JsonWriter(Writer out) {
+    if (out == null) {
+      throw new NullPointerException("out == null");
+    }
+    this.out = out;
+  }
+
+  /**
+   * Sets the indentation string to be repeated for each level of indentation
+   * in the encoded document. If {@code indent.isEmpty()} the encoded document
+   * will be compact. Otherwise the encoded document will be more
+   * human-readable.
+   *
+   * @param indent a string containing only whitespace.
+   */
+  public final void setIndent(String indent) {
+    if (indent.length() == 0) {
+      this.indent = null;
+      this.separator = ":";
+    } else {
+      this.indent = indent;
+      this.separator = ": ";
+    }
+  }
+
+  /**
+   * Configure this writer to relax its syntax rules. By default, this writer
+   * only emits well-formed JSON as specified by <a
+   * href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>. Setting the writer
+   * to lenient permits the following:
+   * <ul>
+   *   <li>Top-level values of any type. With strict writing, the top-level
+   *       value must be an object or an array.
+   *   <li>Numbers may be {@link Double#isNaN() NaNs} or {@link
+   *       Double#isInfinite() infinities}.
+   * </ul>
+   */
+  public final void setLenient(boolean lenient) {
+    this.lenient = lenient;
+  }
+
+  /**
+   * Returns true if this writer has relaxed syntax rules.
+   */
+  public boolean isLenient() {
+    return lenient;
+  }
+
+  /**
+   * Configure this writer to emit JSON that's safe for direct inclusion in HTML
+   * and XML documents. This escapes the HTML characters {@code <}, {@code >},
+   * {@code &} and {@code =} before writing them to the stream. Without this
+   * setting, your XML/HTML encoder should replace these characters with the
+   * corresponding escape sequences.
+   */
+  public final void setHtmlSafe(boolean htmlSafe) {
+    this.htmlSafe = htmlSafe;
+  }
+
+  /**
+   * Returns true if this writer writes JSON that's safe for inclusion in HTML
+   * and XML documents.
+   */
+  public final boolean isHtmlSafe() {
+    return htmlSafe;
+  }
+
+  /**
+   * Sets whether object members are serialized when their value is null.
+   * This has no impact on array elements. The default is true.
+   */
+  public final void setSerializeNulls(boolean serializeNulls) {
+    this.serializeNulls = serializeNulls;
+  }
+
+  /**
+   * Returns true if object members are serialized when their value is null.
+   * This has no impact on array elements. The default is true.
+   */
+  public final boolean getSerializeNulls() {
+    return serializeNulls;
+  }
+
+  /**
+   * Begins encoding a new array. Each call to this method must be paired with
+   * a call to {@link #endArray}.
+   *
+   * @return this writer.
+   */
+  public JsonWriter beginArray() throws IOException {
+    writeDeferredName();
+    return open(EMPTY_ARRAY, '[');
+  }
+
+  /**
+   * Ends encoding the current array.
+   *
+   * @return this writer.
+   */
+  public JsonWriter endArray() throws IOException {
+    return close(EMPTY_ARRAY, NONEMPTY_ARRAY, ']');
+  }
+
+  /**
+   * Begins encoding a new object. Each call to this method must be paired
+   * with a call to {@link #endObject}.
+   *
+   * @return this writer.
+   */
+  public JsonWriter beginObject() throws IOException {
+    writeDeferredName();
+    return open(EMPTY_OBJECT, '{');
+  }
+
+  /**
+   * Ends encoding the current object.
+   *
+   * @return this writer.
+   */
+  public JsonWriter endObject() throws IOException {
+    return close(EMPTY_OBJECT, NONEMPTY_OBJECT, '}');
+  }
+
+  /**
+   * Enters a new scope by appending any necessary whitespace and the given
+   * bracket.
+   */
+  private JsonWriter open(int empty, char openBracket) throws IOException {
+    beforeValue();
+    push(empty);
+    out.write(openBracket);
+    return this;
+  }
+
+  /**
+   * Closes the current scope by appending any necessary whitespace and the
+   * given bracket.
+   */
+  private JsonWriter close(int empty, int nonempty, char closeBracket)
+      throws IOException {
+    int context = peek();
+    if (context != nonempty && context != empty) {
+      throw new IllegalStateException("Nesting problem.");
+    }
+    if (deferredName != null) {
+      throw new IllegalStateException("Dangling name: " + deferredName);
+    }
+
+    stackSize--;
+    if (context == nonempty) {
+      newline();
+    }
+    out.write(closeBracket);
+    return this;
+  }
+
+  private void push(int newTop) {
+    if (stackSize == stack.length) {
+      stack = Arrays.copyOf(stack, stackSize * 2);
+    }
+    stack[stackSize++] = newTop;
+  }
+
+  /**
+   * Returns the value on the top of the stack.
+   */
+  private int peek() {
+    if (stackSize == 0) {
+      throw new IllegalStateException("JsonWriter is closed.");
+    }
+    return stack[stackSize - 1];
+  }
+
+  /**
+   * Replace the value on the top of the stack with the given value.
+   */
+  private void replaceTop(int topOfStack) {
+    stack[stackSize - 1] = topOfStack;
+  }
+
+  /**
+   * Encodes the property name.
+   *
+   * @param name the name of the forthcoming value. May not be null.
+   * @return this writer.
+   */
+  public JsonWriter name(String name) throws IOException {
+    if (name == null) {
+      throw new NullPointerException("name == null");
+    }
+    if (deferredName != null) {
+      throw new IllegalStateException();
+    }
+    if (stackSize == 0) {
+      throw new IllegalStateException("JsonWriter is closed.");
+    }
+    deferredName = name;
+    return this;
+  }
+
+  private void writeDeferredName() throws IOException {
+    if (deferredName != null) {
+      beforeName();
+      string(deferredName);
+      deferredName = null;
+    }
+  }
+
+  /**
+   * Encodes {@code value}.
+   *
+   * @param value the literal string value, or null to encode a null literal.
+   * @return this writer.
+   */
+  public JsonWriter value(String value) throws IOException {
+    if (value == null) {
+      return nullValue();
+    }
+    writeDeferredName();
+    beforeValue();
+    string(value);
+    return this;
+  }
+
+  /**
+   * Writes {@code value} directly to the writer without quoting or
+   * escaping.
+   *
+   * @param value the literal string value, or null to encode a null literal.
+   * @return this writer.
+   */
+  public JsonWriter jsonValue(String value) throws IOException {
+    if (value == null) {
+      return nullValue();
+    }
+    writeDeferredName();
+    beforeValue();
+    out.append(value);
+    return this;
+  }
+
+  /**
+   * Encodes {@code null}.
+   *
+   * @return this writer.
+   */
+  public JsonWriter nullValue() throws IOException {
+    if (deferredName != null) {
+      if (serializeNulls) {
+        writeDeferredName();
+      } else {
+        deferredName = null;
+        return this; // skip the name and the value
+      }
+    }
+    beforeValue();
+    out.write("null");
+    return this;
+  }
+
+  /**
+   * Encodes {@code value}.
+   *
+   * @return this writer.
+   */
+  public JsonWriter value(boolean value) throws IOException {
+    writeDeferredName();
+    beforeValue();
+    out.write(value ? "true" : "false");
+    return this;
+  }
+
+  /**
+   * Encodes {@code value}.
+   *
+   * @return this writer.
+   */
+  public JsonWriter value(Boolean value) throws IOException {
+    if (value == null) {
+      return nullValue();
+    }
+    writeDeferredName();
+    beforeValue();
+    out.write(value ? "true" : "false");
+    return this;
+  }
+
+  /**
+   * Encodes {@code value}.
+   *
+   * @param value a finite value. May not be {@link Double#isNaN() NaNs} or
+   *     {@link Double#isInfinite() infinities}.
+   * @return this writer.
+   */
+  public JsonWriter value(double value) throws IOException {
+    writeDeferredName();
+    if (!lenient && (Double.isNaN(value) || Double.isInfinite(value))) {
+      throw new IllegalArgumentException("Numeric values must be finite, but was " + value);
+    }
+    beforeValue();
+    out.append(Double.toString(value));
+    return this;
+  }
+
+  /**
+   * Encodes {@code value}.
+   *
+   * @return this writer.
+   */
+  public JsonWriter value(long value) throws IOException {
+    writeDeferredName();
+    beforeValue();
+    out.write(Long.toString(value));
+    return this;
+  }
+
+  /**
+   * Encodes {@code value}.
+   *
+   * @param value a finite value. May not be {@link Double#isNaN() NaNs} or
+   *     {@link Double#isInfinite() infinities}.
+   * @return this writer.
+   */
+  public JsonWriter value(Number value) throws IOException {
+    if (value == null) {
+      return nullValue();
+    }
+
+    writeDeferredName();
+    String string = value.toString();
+    if (!lenient
+        && (string.equals("-Infinity") || string.equals("Infinity") || string.equals("NaN"))) {
+      throw new IllegalArgumentException("Numeric values must be finite, but was " + value);
+    }
+    beforeValue();
+    out.append(string);
+    return this;
+  }
+
+  /**
+   * Ensures all buffered data is written to the underlying {@link Writer}
+   * and flushes that writer.
+   */
+  public void flush() throws IOException {
+    if (stackSize == 0) {
+      throw new IllegalStateException("JsonWriter is closed.");
+    }
+    out.flush();
+  }
+
+  /**
+   * Flushes and closes this writer and the underlying {@link Writer}.
+   *
+   * @throws IOException if the JSON document is incomplete.
+   */
+  public void close() throws IOException {
+    out.close();
+
+    int size = stackSize;
+    if (size > 1 || size == 1 && stack[size - 1] != NONEMPTY_DOCUMENT) {
+      throw new IOException("Incomplete document");
+    }
+    stackSize = 0;
+  }
+
+  private void string(String value) throws IOException {
+    String[] replacements = htmlSafe ? HTML_SAFE_REPLACEMENT_CHARS : REPLACEMENT_CHARS;
+    out.write('\"');
+    int last = 0;
+    int length = value.length();
+    for (int i = 0; i < length; i++) {
+      char c = value.charAt(i);
+      String replacement;
+      if (c < 128) {
+        replacement = replacements[c];
+        if (replacement == null) {
+          continue;
+        }
+      } else if (c == '\u2028') {
+        replacement = "\\u2028";
+      } else if (c == '\u2029') {
+        replacement = "\\u2029";
+      } else {
+        continue;
+      }
+      if (last < i) {
+        out.write(value, last, i - last);
+      }
+      out.write(replacement);
+      last = i + 1;
+    }
+    if (last < length) {
+      out.write(value, last, length - last);
+    }
+    out.write('\"');
+  }
+
+  private void newline() throws IOException {
+    if (indent == null) {
+      return;
+    }
+
+    out.write('\n');
+    for (int i = 1, size = stackSize; i < size; i++) {
+      out.write(indent);
+    }
+  }
+
+  /**
+   * Inserts any necessary separators and whitespace before a name. Also
+   * adjusts the stack to expect the name's value.
+   */
+  private void beforeName() throws IOException {
+    int context = peek();
+    if (context == NONEMPTY_OBJECT) { // first in object
+      out.write(',');
+    } else if (context != EMPTY_OBJECT) { // not in an object!
+      throw new IllegalStateException("Nesting problem.");
+    }
+    newline();
+    replaceTop(DANGLING_NAME);
+  }
+
+  /**
+   * Inserts any necessary separators and whitespace before a literal value,
+   * inline array, or inline object. Also adjusts the stack to expect either a
+   * closing bracket or another element.
+   */
+  @SuppressWarnings("fallthrough")
+  private void beforeValue() throws IOException {
+    switch (peek()) {
+      case NONEMPTY_DOCUMENT:
+        if (!lenient) {
+          throw new IllegalStateException(
+              "JSON must have only one top-level value.");
+        }
+        // fall-through
+      case EMPTY_DOCUMENT: // first in document
+        replaceTop(NONEMPTY_DOCUMENT);
+        break;
+
+      case EMPTY_ARRAY: // first in array
+        replaceTop(NONEMPTY_ARRAY);
+        newline();
+        break;
+
+      case NONEMPTY_ARRAY: // another in array
+        out.append(',');
+        newline();
+        break;
+
+      case DANGLING_NAME: // value for name
+        out.append(separator);
+        replaceTop(NONEMPTY_OBJECT);
+        break;
+
+      default:
+        throw new IllegalStateException("Nesting problem.");
+    }
+  }
+}

--- a/benchmarks/src/main/java/net/rsmogura/picoson/benchmarks/UserDataBenchmarksWrite.java
+++ b/benchmarks/src/main/java/net/rsmogura/picoson/benchmarks/UserDataBenchmarksWrite.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.rsmogura.picoson.benchmarks;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import java.io.IOException;
+import net.rsmogura.picoson.JsonWriter;
+import net.rsmogura.picoson.samples.models.UserData;
+import org.apache.commons.io.output.NullWriter;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.CompilerControl.Mode;
+import org.openjdk.jmh.infra.Blackhole;
+
+@CompilerControl(value = Mode.INLINE)
+public class UserDataBenchmarksWrite extends ParsersComparingBenchmark {
+  private static final UserData userData;
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  static {
+    userData = new UserData();
+    userData.setPasswordHash("SHA256:157874489nsvw");
+    userData.setType(2);
+    userData.setActive(true);
+    userData.setUserName("userWrite");
+  }
+
+  @Benchmark
+  @Override
+  public void jackson(Blackhole blackhole) {
+    try {
+      objectMapper.writeValue(new NullWriter(), userData);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Benchmark
+  @Override
+  public void picoson(Blackhole blackhole) {
+    userData.jsonWrite(new JsonWriter(new NullWriter()));
+  }
+
+  @Benchmark
+  @Override
+  public void gson(Blackhole blackhole) {
+    new Gson().toJson(userData, UserData.class, new NullWriter());
+  }
+
+  @Override
+  public void gsonParseOnly(Blackhole blackhole) {
+
+  }
+}

--- a/docs/01_Architecture_overview.md
+++ b/docs/01_Architecture_overview.md
@@ -1,0 +1,64 @@
+# Architecture overview
+
+## What is Picoson
+
+## Why Picoson
+
+## Diagram
+```
++----------------------------+
+|            class           |
+|                            |
+|    +-------------------+   |
+|    |                   |   |
+|    |  class properties |   |
+|    |                   |   |
+|    +-------------------+   |
+|                            |
+|    +-------------------+   |                 +----------------------+
+|    | Picoson generated |   |                 |                      |
+|    | code              |<------------------->|       Picoson        |
+|    |                   |   |                 |         ABI          |
+|    +-------------------+   |                 |                      |
++----------------------------+                 +----------------------+
+```
+
+* Picoson API & ABI do not access non-generated code (no reflection)
+* Generated code:
+   * is responsible for accessing class properties,
+   * can call methods from API & ABI,
+   * can use methods & types from API & ABI for internal purposes
+     (i.e. object descriptors are built using `JsonObjectDescriptorBuilder`)
+
+#Generated class API / ABI overview
+```java
+@Json
+public class Data {
+  @JsonProperty("field1")
+  private String field1;
+
+  /** Contains object descriptor describing all properties in this class
+   * including super class chain. Initialized during class initialization. */
+  static /* synthetic */ JsonObjectDescriptor #jsonDesc;
+
+  protected void #jsonWrite(JSONWriter out) {
+  }
+
+  protected boolean #jsonWriteProp(JsonPropertyDescriptor pd, JsonWriter out) {
+  }
+}
+```
+#ABI
+ABI stands for Application Binary Interface and it's the set of rules for
+interactions between, typically native, applications, libraries and functions;
+in native world it's something like API.
+
+However, as Picoson is statically compiled the term ABI is used instead of
+API (probably increctly), to emphasize significance of (some) generated
+methods and their signature.
+
+The ABI classes, are internal API classes.
+
+# Major classes & packages
+* `Names` - this class containes names used in generated code, many names
+    

--- a/docs/01_Architecture_overview.md
+++ b/docs/01_Architecture_overview.md
@@ -30,15 +30,30 @@
    * can use methods & types from API & ABI for internal purposes
      (i.e. object descriptors are built using `JsonObjectDescriptorBuilder`)
 
-#Generated class API / ABI overview
+# Architecture as Class file
+This is probably better overview of architecture.
 ```java
 @Json
 public class Data {
-  @JsonProperty("field1")
-  private String field1;
+  @JsonProperty("passwordHash")
+  private String passwordHash;
+  /* ... More fields comes here ... */
 
-  /** Contains object descriptor describing all properties in this class
-   * including super class chain. Initialized during class initialization. */
+  /** 
+   * Contains object descriptor, describing all properties in this class
+   * and super class chain. Initialized during (static) class initialization, by
+   * `#jsonInitDesc`.
+   *
+   * The descriptors are used to fast match the property name to code
+   * responsible for reading or writing, this match happens by corresponding
+   * read or write index (integer comparision is faster than string one,
+   * and in Graal VM (when creating this parser) there's no good support for
+   * method references. In addition, this approach is much more faster than
+   * reflection (not even in Graal VM).
+   * 
+   * The (future) purpose of descriptors is to dynamically build class
+   * structure (with help of API) (nothing is implemented now).
+   */
   static /* synthetic */ JsonObjectDescriptor #jsonDesc;
 
   protected /* synthetic */ void #jsonWrite(JSONWriter out) {

--- a/docs/01_Architecture_overview.md
+++ b/docs/01_Architecture_overview.md
@@ -41,24 +41,55 @@ public class Data {
    * including super class chain. Initialized during class initialization. */
   static /* synthetic */ JsonObjectDescriptor #jsonDesc;
 
-  protected void #jsonWrite(JSONWriter out) {
+  protected /* synthetic */ void #jsonWrite(JSONWriter out) {
+      out.beginObject();
+      JsonPropertyDescriptor[] props = #jsonDesc.getProperties();
+      int propsLen = props.length;
+      // Iterate over all properties in descriptor
+      for(int i = 0; i < propsLen; ++i) {
+        this.#jsonWriteProp(props[i], out);
+      }
+
+      var1.endObject();
   }
 
   protected boolean #jsonWriteProp(JsonPropertyDescriptor pd, JsonWriter out) {
+      int var3 = var1.getWritePropertyIndex();
+      // 1 is the property index assigned during class transformation
+      // it corresponds to passwordHash field, and it's used to speed
+      // up searching for properties.
+      //
+      // The if-else-if tree (pending optimization)
+      // is generated inside `PropertyAbstractGenerator.generate`.
+      if (var3 == 1) {
+        var2.name(var1.getJsonPropertyName()).value(this.passwordHash);
+        return (boolean)1;
+      } else if (var3 == 3) {
+        var2.name(var1.getJsonPropertyName()).value(this.active);
+        return (boolean)1;
+      } else if (var3 == 0) {
+        var2.name(var1.getJsonPropertyName()).value(this.userName);
+        return (boolean)1;
+      } else if (var3 == 2) {
+        var2.name(var1.getJsonPropertyName()).value((long)this.type);
+        return (boolean)1;
+      } else {
+        return (boolean)0;
+      }
   }
 }
 ```
 #ABI
 ABI stands for Application Binary Interface and it's the set of rules for
-interactions between, typically native, applications, libraries and functions;
+interactions between, typically native applications, libraries and functions;
 in native world it's something like API.
 
 However, as Picoson is statically compiled the term ABI is used instead of
-API (probably increctly), to emphasize significance of (some) generated
+API (probably incorrectly), to emphasize significance of (some) generated
 methods and their signature.
 
 The ABI classes, are internal API classes.
 
 # Major classes & packages
-* `Names` - this class containes names used in generated code, many names
+* `Names` - this class contains names used in generated code, many names
     

--- a/docs/compare.md
+++ b/docs/compare.md
@@ -1,0 +1,19 @@
+# Info
+Contains various comparisions to justify why this way not the other
+
+# JsonObjectDescriptor getProperties returns array
+
+```text
+Array version JsonPropertyDescriptor[] of JsonObjectDescriptor.getProperties
+
+Benchmark                         Mode  Cnt        Score        Error  Units
+UserDataBenchmarksWrite.gson     thrpt    5   218382.152 ±   5580.687  ops/s
+UserDataBenchmarksWrite.jackson  thrpt    5  3913127.362 ± 173774.121  ops/s
+UserDataBenchmarksWrite.picoson  thrpt    5  6427794.525 ± 168717.757  ops/s
+
+ArrayList<JsonObjectDescriptor> version of JsonObjectDescriptor.getProperties
+Benchmark                         Mode  Cnt        Score        Error  Units
+UserDataBenchmarksWrite.gson     thrpt    5   216734.875 ±   3560.100  ops/s
+UserDataBenchmarksWrite.jackson  thrpt    5  3958068.924 ±  84360.951  ops/s
+UserDataBenchmarksWrite.picoson  thrpt    5  6049388.910 ± 182620.426  ops/s
+```

--- a/generator-core/src/main/java/net/rsmogura/picoson/generator/core/AbstractMethodGenerator.java
+++ b/generator-core/src/main/java/net/rsmogura/picoson/generator/core/AbstractMethodGenerator.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.rsmogura.picoson.generator.core;
+
+import javax.lang.model.util.Elements;
+import net.rsmogura.picoson.generator.core.analyze.PropertiesCollector;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
+
+public class AbstractMethodGenerator {
+
+  protected final MethodVisitor mv;
+  protected final Type owner;
+  protected final Elements elements;
+  protected final PropertiesCollector propertiesCollector;
+  protected final GeneratorUtils utils;
+
+  public AbstractMethodGenerator(
+      MethodVisitor mv, Type owner, Elements elements, PropertiesCollector propertiesCollector) {
+    this.mv = mv;
+    this.owner = owner;
+    this.elements = elements;
+    this.propertiesCollector = propertiesCollector;
+    this.utils = new GeneratorUtils(this.elements);
+  }
+}

--- a/generator-core/src/main/java/net/rsmogura/picoson/generator/core/BinaryNames.java
+++ b/generator-core/src/main/java/net/rsmogura/picoson/generator/core/BinaryNames.java
@@ -18,8 +18,15 @@ package net.rsmogura.picoson.generator.core;
 import static org.objectweb.asm.Type.BOOLEAN_TYPE;
 import static org.objectweb.asm.Type.INT_TYPE;
 import static org.objectweb.asm.Type.LONG_TYPE;
+import static org.objectweb.asm.Type.OBJECT;
+import static org.objectweb.asm.Type.VOID_TYPE;
+import static org.objectweb.asm.Type.getMethodDescriptor;
+import static org.objectweb.asm.Type.getType;
 
+import java.util.Collection;
 import net.rsmogura.picoson.JsonReader;
+import net.rsmogura.picoson.JsonWriter;
+import net.rsmogura.picoson.abi.JsonObjectDescriptor;
 import net.rsmogura.picoson.abi.JsonPropertyDescriptor;
 import net.rsmogura.picoson.annotations.Json;
 import org.objectweb.asm.Type;
@@ -28,6 +35,9 @@ import org.objectweb.asm.Type;
  * Contains binary names and descriptors used to generate code.
  */
 public final class BinaryNames {
+  // TODO (Minor performance) - number of descriptors here can be strings
+  //      no need to build those during initialization (it's always some
+  //      performance impr. for compilation time)
   /**
    * Descriptor for annotation {@link net.rsmogura.picoson.annotations.Json}.
    */
@@ -35,17 +45,28 @@ public final class BinaryNames {
 
   /** Descriptor for {@link net.rsmogura.picoson.abi.Names#READ_PROPERTY_NAME} */
   public static final String READ_PROPERTY_DESCRIPTOR =
-      Type.getMethodDescriptor(BOOLEAN_TYPE,
-          Type.getType(JsonPropertyDescriptor.class), Type.getType(JsonReader.class));
-
+      getMethodDescriptor(BOOLEAN_TYPE,
+          getType(JsonPropertyDescriptor.class), getType(JsonReader.class));
 
   public static final String JSON_READER_NAME = Type.getInternalName(JsonReader.class);
 
+  /**
+   * Descriptor for {@link net.rsmogura.picoson.abi.Names#INSTANCE_SERIALIZE_METHOD_NAME}
+   */
+  public static final String INSTANCE_SERIALIZE_METHOD_DESC =
+      getMethodDescriptor(VOID_TYPE, getType(JsonWriter.class));
+
+  /** Descriptor for {@link net.rsmogura.picoson.abi.Names#WRITE_PROPERTY_NAME} */
+  public static final String WRITE_PROPERTY_DESCRIPTOR =
+      getMethodDescriptor(BOOLEAN_TYPE,
+          getType(JsonPropertyDescriptor.class), getType(JsonWriter.class));
+
+  /** Internal name for {@link JsonWriter}. */
+  public static final String JSON_WRITER_NAME = Type.getInternalName(JsonWriter.class);
 
   /** Internal name for {@link net.rsmogura.picoson.abi.JsonPropertyDescriptor} */
   public static final String JSON_PROPERTY_DESCRIPTOR_NAME =
       Type.getInternalName(JsonPropertyDescriptor.class);
-
 
   /**
    * Method descriptor for obtaining reader index
@@ -53,23 +74,50 @@ public final class BinaryNames {
    */
   public static final String GET_READ_INDEX_DESCRIPTOR;
 
+  /** No arg method, returning Object. */
+  public static final String OBJECT_RETURNING_METHOD = getMethodDescriptor(
+      getType(Object.class)
+  );
+
   /** No arg method, returning boolean. */
-  public static final String BOOL_RETURNING_METHOD = Type.getMethodDescriptor(BOOLEAN_TYPE);
+  public static final String BOOL_RETURNING_METHOD = getMethodDescriptor(BOOLEAN_TYPE);
 
   /** No arg method, returning int. */
-  public static final String INT_RETURNING_METHOD = Type.getMethodDescriptor(INT_TYPE);
+  public static final String INT_RETURNING_METHOD = getMethodDescriptor(INT_TYPE);
 
   /** No arg method, returning long. */
-  public static final String LONG_RETURNING_METHOD = Type.getMethodDescriptor(LONG_TYPE);
+  public static final String LONG_RETURNING_METHOD = getMethodDescriptor(LONG_TYPE);
+
+  public static final String JSON_WRITER_RETURNING_METHOD
+      = getMethodDescriptor(getType(JsonWriter.class));
+
+  /** No arg method, returning {@link java.util.Collection}. */
+  public static final String COLLECTION_RETURNING_METHOD =
+      getMethodDescriptor(getType(Collection.class));
 
   /** No arg method, returning String. */
   public static final String STRING_RETURNING_METHOD =
-      Type.getMethodDescriptor(Type.getType(String.class));
+      getMethodDescriptor(getType(String.class));
 
+  public static final String JSON_WRITE_STRING_VALUE =
+      getMethodDescriptor(getType(JsonWriter.class), getType(String.class));
+
+  /**
+   * Descriptor for {@link JsonObjectDescriptor}
+   */
+  public static final String JSON_OBJECT_DESCRIPTOR =
+      Type.getDescriptor(JsonObjectDescriptor.class);
+
+  /** Internal name for {@link JsonObjectDescriptor}. */
+  public static final String JSON_OBJECT_DESCRIPTOR_NAME =
+      Type.getInternalName(JsonObjectDescriptor.class);
+
+  public static final String JSON_OBJECT_DESCRIPTOR_GET_PROPERTIES_DESC =
+      COLLECTION_RETURNING_METHOD;
 
   static {
     try {
-      GET_READ_INDEX_DESCRIPTOR = Type.getMethodDescriptor(
+      GET_READ_INDEX_DESCRIPTOR = getMethodDescriptor(
           JsonPropertyDescriptor.class.getDeclaredMethod("getReadPropertyIndex"));
     } catch (NoSuchMethodException e) {
       throw new PicosonGeneratorException("Error while initializing class", e);

--- a/generator-core/src/main/java/net/rsmogura/picoson/generator/core/BinaryNames.java
+++ b/generator-core/src/main/java/net/rsmogura/picoson/generator/core/BinaryNames.java
@@ -113,7 +113,7 @@ public final class BinaryNames {
       Type.getInternalName(JsonObjectDescriptor.class);
 
   public static final String JSON_OBJECT_DESCRIPTOR_GET_PROPERTIES_DESC =
-      COLLECTION_RETURNING_METHOD;
+      getMethodDescriptor(getType(JsonPropertyDescriptor[].class));
 
   static {
     try {

--- a/generator-core/src/main/java/net/rsmogura/picoson/generator/core/GeneratorUtils.java
+++ b/generator-core/src/main/java/net/rsmogura/picoson/generator/core/GeneratorUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.rsmogura.picoson.generator.core;
+
+import javax.lang.model.element.Name;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+
+/**
+ * Utility class.
+ */
+public class GeneratorUtils {
+  private final Elements elements;
+
+  public GeneratorUtils(Elements elements) {
+    this.elements = elements;
+  }
+
+  public String descriptorFromType(TypeElement typeElement) {
+    final Name binaryName = elements.getBinaryName(typeElement);
+    return "L" + binaryName.toString().replaceAll("\\.", "/") + ";";
+  }
+}

--- a/generator-core/src/main/java/net/rsmogura/picoson/generator/core/ObjectSerializerGenerator.java
+++ b/generator-core/src/main/java/net/rsmogura/picoson/generator/core/ObjectSerializerGenerator.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.rsmogura.picoson.generator.core;
+
+import static net.rsmogura.picoson.abi.Names.WRITE_PROPERTY_NAME;
+import static net.rsmogura.picoson.generator.core.BinaryNames.BOOL_RETURNING_METHOD;
+import static net.rsmogura.picoson.generator.core.BinaryNames.JSON_OBJECT_DESCRIPTOR;
+import static net.rsmogura.picoson.generator.core.BinaryNames.JSON_OBJECT_DESCRIPTOR_GET_PROPERTIES_DESC;
+import static net.rsmogura.picoson.generator.core.BinaryNames.JSON_OBJECT_DESCRIPTOR_NAME;
+import static net.rsmogura.picoson.generator.core.BinaryNames.JSON_PROPERTY_DESCRIPTOR_NAME;
+import static net.rsmogura.picoson.generator.core.BinaryNames.JSON_WRITER_NAME;
+import static net.rsmogura.picoson.generator.core.BinaryNames.JSON_WRITER_RETURNING_METHOD;
+import static net.rsmogura.picoson.generator.core.BinaryNames.OBJECT_RETURNING_METHOD;
+import static net.rsmogura.picoson.generator.core.BinaryNames.WRITE_PROPERTY_DESCRIPTOR;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.ASTORE;
+import static org.objectweb.asm.Opcodes.CHECKCAST;
+import static org.objectweb.asm.Opcodes.DUP_X1;
+import static org.objectweb.asm.Opcodes.GETSTATIC;
+import static org.objectweb.asm.Opcodes.GOTO;
+import static org.objectweb.asm.Opcodes.IFEQ;
+import static org.objectweb.asm.Opcodes.IFNE;
+import static org.objectweb.asm.Opcodes.INVOKEINTERFACE;
+import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
+import static org.objectweb.asm.Opcodes.POP;
+import static org.objectweb.asm.Opcodes.RETURN;
+import static org.objectweb.asm.Type.getInternalName;
+import static org.objectweb.asm.Type.getMethodDescriptor;
+import static org.objectweb.asm.Type.getType;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import javax.lang.model.util.Elements;
+import net.rsmogura.picoson.abi.Names;
+import net.rsmogura.picoson.generator.core.analyze.PropertiesCollector;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+public class ObjectSerializerGenerator extends AbstractMethodGenerator {
+  public ObjectSerializerGenerator(MethodVisitor mv, Type owner,
+      Elements elements,
+      PropertiesCollector propertiesCollector) {
+    super(mv, owner, elements, propertiesCollector);
+  }
+
+  public void generate() {
+    final int iteratorLocal = 2;
+    final Label propertiesLoopLabel = new Label();
+    final Label propertiesLoopEnd = new Label();
+
+    generateBeginObject();
+    generatePropertiesDescriptorIterator(iteratorLocal);
+
+    // While iterator.hasNext
+    mv.visitLabel(propertiesLoopLabel);
+    mv.visitVarInsn(ALOAD, iteratorLocal);
+    mv.visitMethodInsn(INVOKEINTERFACE, getInternalName(Iterator.class),
+        "hasNext", BOOL_RETURNING_METHOD, true);
+    mv.visitJumpInsn(IFEQ, propertiesLoopEnd);
+
+    // #jsonWriteProp(iterator.next())
+    mv.visitVarInsn(ALOAD, 0);
+    mv.visitVarInsn(ALOAD, iteratorLocal);
+    mv.visitMethodInsn(INVOKEINTERFACE, getInternalName(Iterator.class),
+        "next", OBJECT_RETURNING_METHOD, true);
+    mv.visitTypeInsn(CHECKCAST, JSON_PROPERTY_DESCRIPTOR_NAME);
+    mv.visitVarInsn(ALOAD, 1);
+    mv.visitMethodInsn(INVOKEVIRTUAL, owner.getInternalName(),
+        WRITE_PROPERTY_NAME, WRITE_PROPERTY_DESCRIPTOR, false);
+    mv.visitInsn(POP); // pop boolean result
+
+    mv.visitJumpInsn(GOTO, propertiesLoopLabel);
+    mv.visitLabel(propertiesLoopEnd);
+
+    generateEndObject();
+    mv.visitInsn(RETURN);
+    mv.visitMaxs(0, 0);
+    mv.visitEnd();
+  }
+
+  protected void generatePropertiesDescriptorIterator(int iteratorLocal) {
+    mv.visitFieldInsn(GETSTATIC, owner.getInternalName(),
+        Names.DESCRIPTOR_HOLDER, JSON_OBJECT_DESCRIPTOR);
+    mv.visitMethodInsn(INVOKEVIRTUAL, JSON_OBJECT_DESCRIPTOR_NAME,
+        "getProperties", JSON_OBJECT_DESCRIPTOR_GET_PROPERTIES_DESC, false);
+    mv.visitMethodInsn(INVOKEINTERFACE, getInternalName(Collection.class),
+        "iterator", getMethodDescriptor(getType(Iterator.class)), true);
+    mv.visitVarInsn(ASTORE, iteratorLocal);
+  }
+
+  protected void generateBeginObject() {
+    mv.visitVarInsn(ALOAD, 1);
+    mv.visitMethodInsn(INVOKEVIRTUAL, JSON_WRITER_NAME,
+        "beginObject", JSON_WRITER_RETURNING_METHOD, false);
+    mv.visitInsn(POP);
+  }
+
+  protected void generateEndObject() {
+    mv.visitVarInsn(ALOAD, 1);
+    mv.visitMethodInsn(INVOKEVIRTUAL, JSON_WRITER_NAME,
+        "endObject", JSON_WRITER_RETURNING_METHOD, false);
+    mv.visitInsn(POP);
+  }
+}

--- a/generator-core/src/main/java/net/rsmogura/picoson/generator/core/PicosonJavacClassTransformer.java
+++ b/generator-core/src/main/java/net/rsmogura/picoson/generator/core/PicosonJavacClassTransformer.java
@@ -145,7 +145,7 @@ public class PicosonJavacClassTransformer extends ClassVisitor {
 
   protected void generateObjectWriter(final Type thizClassType) {
     final MethodVisitor objectSerializerMv = cv.visitMethod(
-        ACC_PROTECTED | ACC_SYNTHETIC, INSTANCE_SERIALIZE_METHOD_NAME,
+        ACC_PROTECTED, INSTANCE_SERIALIZE_METHOD_NAME,
         INSTANCE_SERIALIZE_METHOD_DESC, null, null);
     new ObjectSerializerGenerator(objectSerializerMv, thizClassType, elements, propertiesCollector)
         .generate();

--- a/generator-core/src/main/java/net/rsmogura/picoson/generator/core/PropertyAbstractGenerator.java
+++ b/generator-core/src/main/java/net/rsmogura/picoson/generator/core/PropertyAbstractGenerator.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.rsmogura.picoson.generator.core;
+
+import static javax.lang.model.type.TypeKind.DECLARED;
+import static net.rsmogura.picoson.generator.core.BinaryNames.GET_READ_INDEX_DESCRIPTOR;
+import static net.rsmogura.picoson.generator.core.BinaryNames.JSON_PROPERTY_DESCRIPTOR_NAME;
+import static net.rsmogura.picoson.generator.core.BinaryNames.JSON_READER_NAME;
+import static net.rsmogura.picoson.generator.core.BinaryNames.STRING_RETURNING_METHOD;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.IF_ICMPNE;
+import static org.objectweb.asm.Opcodes.ILOAD;
+import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
+import static org.objectweb.asm.Opcodes.ISTORE;
+import static org.objectweb.asm.Opcodes.PUTFIELD;
+
+import javax.lang.model.element.Name;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import net.rsmogura.picoson.abi.Names;
+import net.rsmogura.picoson.generator.core.analyze.FieldProperty;
+import net.rsmogura.picoson.generator.core.analyze.PropertiesCollector;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+public abstract class PropertyAbstractGenerator extends AbstractMethodGenerator {
+  protected static final int PARAM_THIS = 0;
+  protected static final int PARAM_DESC = 1;
+  protected static final int PARAM_READER_WRITER = 2;
+  protected static final int PARAM_DESCRIPTOR_IDX = 3;
+
+  public PropertyAbstractGenerator(MethodVisitor mv, Type owner,
+      Elements elements,
+      PropertiesCollector propertiesCollector) {
+    super(mv, owner, elements, propertiesCollector);
+  }
+
+  public void generate() {
+    // Read index of property, and store it as local, this has been
+    // determined as having big performance impact for reading large objects
+    mv.visitVarInsn(ALOAD, PARAM_DESC);
+    mv.visitMethodInsn(INVOKEVIRTUAL, JSON_PROPERTY_DESCRIPTOR_NAME,
+        "getReadPropertyIndex", GET_READ_INDEX_DESCRIPTOR, false);
+    mv.visitVarInsn(ISTORE, PARAM_DESCRIPTOR_IDX);
+
+    // TODO This is if-else-if block, which is terrible slow, for large number of properties
+    //      This should be changed to BST.
+    for (FieldProperty fp : propertiesCollector.getJsonProperties().values()) {
+      final Label elseBlock = new Label();
+      mv.visitVarInsn(ILOAD, PARAM_DESCRIPTOR_IDX);
+      mv.visitLdcInsn(fp.getReadIndex());
+      mv.visitJumpInsn(IF_ICMPNE, elseBlock);
+
+      // Normal block
+      handleProperty(fp);
+      mv.visitLdcInsn(true);
+      mv.visitInsn(Opcodes.IRETURN);
+
+      // Begin else block. Because we have return in every true-block
+      // no need to generate skip all label, to jump to the end of if-else
+      // tree.
+      mv.visitLabel(elseBlock);
+    }
+    mv.visitLabel(new Label());
+    mv.visitLdcInsn(false);
+    mv.visitInsn(Opcodes.IRETURN);
+    mv.visitMaxs(0, 0);
+    mv.visitEnd();
+  }
+
+  protected void handleProperty(FieldProperty fieldProperty) {
+    final VariableElement fieldElement = fieldProperty.getFieldElement();
+    final TypeMirror propertyType = fieldElement.asType();
+    final TypeKind typeKind = propertyType.getKind();
+
+    if (typeKind == DECLARED) {
+      final DeclaredType declaredType = (DeclaredType) propertyType;
+      handleReferenceProperty(fieldProperty, declaredType);
+    } else if (typeKind.isPrimitive()) {
+      handlePrimitiveProperty(fieldProperty, propertyType);
+    }
+  }
+
+  protected abstract void handlePrimitiveProperty(FieldProperty fieldProperty,
+      TypeMirror propertyType);
+
+  protected void handleReferenceProperty(FieldProperty fieldProperty,
+      DeclaredType declaredType) {
+    final TypeElement typeElement = (TypeElement) declaredType.asElement();
+    final Name binaryName = elements.getBinaryName(typeElement);
+
+    if (binaryName.contentEquals(String.class.getName())) {
+      preHandleReferenceProperty(fieldProperty, declaredType);
+      handleString(fieldProperty, declaredType);
+      postHandleReferenceProperty(fieldProperty, declaredType);
+    }
+  }
+
+  protected abstract void preHandleReferenceProperty(FieldProperty fieldProperty,
+      DeclaredType declaredType);
+  protected abstract void postHandleReferenceProperty(FieldProperty fieldProperty,
+      DeclaredType declaredType);
+
+  protected abstract void handleString(FieldProperty fieldProperty,
+      DeclaredType declaredType);
+}

--- a/generator-core/src/main/java/net/rsmogura/picoson/generator/core/PropertyReaderGenerator.java
+++ b/generator-core/src/main/java/net/rsmogura/picoson/generator/core/PropertyReaderGenerator.java
@@ -15,7 +15,6 @@
 
 package net.rsmogura.picoson.generator.core;
 
-import static javax.lang.model.type.TypeKind.DECLARED;
 import static net.rsmogura.picoson.generator.core.BinaryNames.BOOL_RETURNING_METHOD;
 import static net.rsmogura.picoson.generator.core.BinaryNames.GET_READ_INDEX_DESCRIPTOR;
 import static net.rsmogura.picoson.generator.core.BinaryNames.INT_RETURNING_METHOD;
@@ -24,27 +23,19 @@ import static net.rsmogura.picoson.generator.core.BinaryNames.JSON_READER_NAME;
 import static net.rsmogura.picoson.generator.core.BinaryNames.LONG_RETURNING_METHOD;
 import static net.rsmogura.picoson.generator.core.BinaryNames.STRING_RETURNING_METHOD;
 import static org.objectweb.asm.Opcodes.ALOAD;
-import static org.objectweb.asm.Opcodes.IF_ICMPNE;
-import static org.objectweb.asm.Opcodes.ILOAD;
 import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
-import static org.objectweb.asm.Opcodes.ISTORE;
 import static org.objectweb.asm.Opcodes.PUTFIELD;
 import static org.objectweb.asm.Type.BOOLEAN_TYPE;
 import static org.objectweb.asm.Type.INT_TYPE;
 import static org.objectweb.asm.Type.LONG_TYPE;
 
-import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import net.rsmogura.picoson.generator.core.analyze.FieldProperty;
 import net.rsmogura.picoson.generator.core.analyze.PropertiesCollector;
-import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
 /**
@@ -56,6 +47,20 @@ public class PropertyReaderGenerator extends PropertyAbstractGenerator {
   public PropertyReaderGenerator(MethodVisitor mv, Type owner,
       Elements elements, PropertiesCollector propertiesCollector) {
     super(mv, owner, elements, propertiesCollector);
+  }
+
+  @Override
+  protected void getPropertyId() {
+    // Read index of property, and store it as local, this has been
+    // determined as having big performance impact for reading large objects
+    mv.visitVarInsn(ALOAD, PARAM_DESC);
+    mv.visitMethodInsn(INVOKEVIRTUAL, JSON_PROPERTY_DESCRIPTOR_NAME,
+        "getReadPropertyIndex", GET_READ_INDEX_DESCRIPTOR, false);
+  }
+
+  @Override
+  protected int getPropertyIndexForCompare(FieldProperty fp) {
+    return fp.getReadIndex();
   }
 
   protected void handlePrimitiveProperty(FieldProperty fieldProperty,

--- a/generator-core/src/main/java/net/rsmogura/picoson/generator/core/PropertyWriterGenerator.java
+++ b/generator-core/src/main/java/net/rsmogura/picoson/generator/core/PropertyWriterGenerator.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.rsmogura.picoson.generator.core;
+
+import static net.rsmogura.picoson.generator.core.BinaryNames.BOOL_RETURNING_METHOD;
+import static net.rsmogura.picoson.generator.core.BinaryNames.COLLECTION_RETURNING_METHOD;
+import static net.rsmogura.picoson.generator.core.BinaryNames.INT_RETURNING_METHOD;
+import static net.rsmogura.picoson.generator.core.BinaryNames.JSON_OBJECT_DESCRIPTOR_NAME;
+import static net.rsmogura.picoson.generator.core.BinaryNames.JSON_PROPERTY_DESCRIPTOR_NAME;
+import static net.rsmogura.picoson.generator.core.BinaryNames.JSON_WRITER_NAME;
+import static net.rsmogura.picoson.generator.core.BinaryNames.JSON_WRITE_STRING_VALUE;
+import static net.rsmogura.picoson.generator.core.BinaryNames.LONG_RETURNING_METHOD;
+import static net.rsmogura.picoson.generator.core.BinaryNames.STRING_RETURNING_METHOD;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.GETFIELD;
+import static org.objectweb.asm.Opcodes.I2L;
+import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
+import static org.objectweb.asm.Type.BOOLEAN_TYPE;
+import static org.objectweb.asm.Type.INT_TYPE;
+import static org.objectweb.asm.Type.LONG_TYPE;
+import static org.objectweb.asm.Type.VOID_TYPE;
+import static org.objectweb.asm.Type.getMethodDescriptor;
+import static org.objectweb.asm.Type.getType;
+
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import net.rsmogura.picoson.JsonWriter;
+import net.rsmogura.picoson.generator.core.analyze.FieldProperty;
+import net.rsmogura.picoson.generator.core.analyze.PropertiesCollector;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
+
+public class PropertyWriterGenerator extends PropertyAbstractGenerator{
+
+  public PropertyWriterGenerator(MethodVisitor mv, Type owner,
+      Elements elements,
+      PropertiesCollector propertiesCollector) {
+    super(mv, owner, elements, propertiesCollector);
+  }
+
+  @Override
+  protected void handlePrimitiveProperty(FieldProperty fieldProperty, TypeMirror propertyType) {
+    this.writePropertyName(fieldProperty); // After it JsonWriter on stack
+
+    final Type fieldDescriptor;
+    final String writeMethodDesc;
+
+    // Right now JsonWriter has only long version of value, so 32bit integers
+    // has to be casted to long.
+    // Same story for floats
+    boolean castToLong = false;
+
+    // I really don't like this switch for primitives
+    switch (propertyType.getKind()) {
+      case INT:
+        // TODO Extract method descriptors to constants
+        writeMethodDesc = getMethodDescriptor(getType(JsonWriter.class), LONG_TYPE);
+        fieldDescriptor = INT_TYPE;
+        castToLong = true;
+        break;
+      case BOOLEAN:
+        writeMethodDesc = getMethodDescriptor(getType(JsonWriter.class), BOOLEAN_TYPE);
+        fieldDescriptor = BOOLEAN_TYPE;
+        break;
+      case LONG:
+        writeMethodDesc = getMethodDescriptor(getType(JsonWriter.class), LONG_TYPE);
+        fieldDescriptor = LONG_TYPE;
+        break;
+      default:
+        throw new PicosonGeneratorException("Unsupported primitive type "
+            + propertyType + " for property "
+            + fieldProperty.getPropertyName() + " in " + owner);
+    }
+
+    mv.visitVarInsn(ALOAD, PARAM_THIS);
+    mv.visitFieldInsn(GETFIELD, owner.getInternalName(),
+        fieldProperty.getFieldElement().getSimpleName().toString(),
+        fieldDescriptor.getDescriptor());
+
+    if (castToLong) {
+      mv.visitInsn(I2L);
+    }
+
+    mv.visitMethodInsn(INVOKEVIRTUAL, JSON_WRITER_NAME,
+        "value", writeMethodDesc, false);
+  }
+
+  @Override
+  protected void preHandleReferenceProperty(FieldProperty fieldProperty,
+      DeclaredType declaredType) {
+
+    this.writePropertyName(fieldProperty); // After it JsonWriter on stack
+
+    // Put value of property
+    mv.visitVarInsn(ALOAD, PARAM_THIS);
+    mv.visitFieldInsn(GETFIELD, owner.getInternalName(),
+        fieldProperty.getFieldElement().getSimpleName().toString(),
+        utils.descriptorFromType((TypeElement) declaredType.asElement()));
+  }
+
+  @Override
+  protected void postHandleReferenceProperty(FieldProperty fieldProperty,
+      DeclaredType declaredType) {
+    //Nothing to do here
+  }
+
+  @Override
+  protected void handleString(FieldProperty fieldProperty, DeclaredType declaredType) {
+    mv.visitMethodInsn(INVOKEVIRTUAL, JSON_WRITER_NAME,
+        "value", JSON_WRITE_STRING_VALUE, false);
+  }
+
+  /**
+   * Writes property name to output JSON. On stack will be {@link JsonWriter}
+   * @param fieldProperty
+   */
+  protected void writePropertyName(FieldProperty fieldProperty) {
+    mv.visitVarInsn(ALOAD, PARAM_READER_WRITER);
+    mv.visitVarInsn(ALOAD, PARAM_DESC);
+    mv.visitMethodInsn(INVOKEVIRTUAL, JSON_PROPERTY_DESCRIPTOR_NAME,
+        "getJsonPropertyName", STRING_RETURNING_METHOD, false);
+    // On stack writer, property name
+    mv.visitMethodInsn(INVOKEVIRTUAL, JSON_WRITER_NAME,
+        "name", JSON_WRITE_STRING_VALUE, false);
+    // On stack writer
+  }
+}

--- a/generator-core/src/main/java/net/rsmogura/picoson/generator/core/PropertyWriterGenerator.java
+++ b/generator-core/src/main/java/net/rsmogura/picoson/generator/core/PropertyWriterGenerator.java
@@ -15,14 +15,10 @@
 
 package net.rsmogura.picoson.generator.core;
 
-import static net.rsmogura.picoson.generator.core.BinaryNames.BOOL_RETURNING_METHOD;
-import static net.rsmogura.picoson.generator.core.BinaryNames.COLLECTION_RETURNING_METHOD;
-import static net.rsmogura.picoson.generator.core.BinaryNames.INT_RETURNING_METHOD;
-import static net.rsmogura.picoson.generator.core.BinaryNames.JSON_OBJECT_DESCRIPTOR_NAME;
+import static net.rsmogura.picoson.generator.core.BinaryNames.GET_READ_INDEX_DESCRIPTOR;
 import static net.rsmogura.picoson.generator.core.BinaryNames.JSON_PROPERTY_DESCRIPTOR_NAME;
 import static net.rsmogura.picoson.generator.core.BinaryNames.JSON_WRITER_NAME;
 import static net.rsmogura.picoson.generator.core.BinaryNames.JSON_WRITE_STRING_VALUE;
-import static net.rsmogura.picoson.generator.core.BinaryNames.LONG_RETURNING_METHOD;
 import static net.rsmogura.picoson.generator.core.BinaryNames.STRING_RETURNING_METHOD;
 import static org.objectweb.asm.Opcodes.ALOAD;
 import static org.objectweb.asm.Opcodes.GETFIELD;
@@ -31,7 +27,6 @@ import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
 import static org.objectweb.asm.Type.BOOLEAN_TYPE;
 import static org.objectweb.asm.Type.INT_TYPE;
 import static org.objectweb.asm.Type.LONG_TYPE;
-import static org.objectweb.asm.Type.VOID_TYPE;
 import static org.objectweb.asm.Type.getMethodDescriptor;
 import static org.objectweb.asm.Type.getType;
 
@@ -51,6 +46,20 @@ public class PropertyWriterGenerator extends PropertyAbstractGenerator{
       Elements elements,
       PropertiesCollector propertiesCollector) {
     super(mv, owner, elements, propertiesCollector);
+  }
+
+  @Override
+  protected void getPropertyId() {
+    // Read index of property, and store it as local, this has been
+    // determined as having big performance impact for reading large objects
+    mv.visitVarInsn(ALOAD, PARAM_DESC);
+    mv.visitMethodInsn(INVOKEVIRTUAL, JSON_PROPERTY_DESCRIPTOR_NAME,
+        "getWritePropertyIndex", GET_READ_INDEX_DESCRIPTOR, false);
+  }
+
+  @Override
+  protected int getPropertyIndexForCompare(FieldProperty fp) {
+    return fp.getWriteIndex();
   }
 
   @Override

--- a/tests/src/test/java/net/rsmogura/picoson/tests/ReadWriteTest.java
+++ b/tests/src/test/java/net/rsmogura/picoson/tests/ReadWriteTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.rsmogura.picoson.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import java.io.CharArrayReader;
+import java.io.CharArrayWriter;
+import java.util.HashMap;
+import java.util.Random;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.SneakyThrows;
+import net.rsmogura.picoson.JsonReader;
+import net.rsmogura.picoson.JsonWriter;
+import net.rsmogura.picoson.annotations.Json;
+import net.rsmogura.picoson.annotations.JsonProperty;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Read-write tests This tests reads JSON writes it and reads again to check
+ * if values are serialized correctly.
+ */
+public class ReadWriteTest {
+  private Random random = new Random(System.currentTimeMillis());
+
+  private HashMap<String, Integer> nullChecksMap = new HashMap<>();
+
+  /**
+   * This test creates input class with random data, clones it
+   * serializes to JSON and deserializes from JSON to check if data
+   * are same.
+   * <br />
+   * This test uses pseudo random values, and invokes number of passes to be
+   * absolutely sure.
+   * <br />
+   * Number of passes is required to check null values serialization.
+   */
+  @Test
+  public void testReadWrite() throws Exception {
+    for (int i=0; i < 1000; i++) {
+      testReadWriteCheck();
+    }
+  }
+
+  protected void testReadWriteCheck() {
+    final ReadWriteTestModel srcModel = prepareSampleModel();
+    final ReadWriteTestModel toSerializeData = srcModel.clone();
+    final ReadWriteTestModel readData;
+
+    try(CharArrayWriter writeBuff = new CharArrayWriter();
+        JsonWriter writer = new JsonWriter(writeBuff)) {
+      toSerializeData.jsonWrite(writer);
+      writer.flush();
+
+      try (CharArrayReader readBuff = new CharArrayReader(writeBuff.toCharArray())) {
+        readData = ReadWriteTestModel.jsonRead(new JsonReader(readBuff));
+      }
+    }
+
+    // Sanity checks (just to test tests)
+    assertNotSame(srcModel, toSerializeData);
+    assertNotSame(toSerializeData, readData);
+    assertNotSame(srcModel, readData);
+
+    // Check if clone and data to serialize are same
+    assertEquals(srcModel, toSerializeData);
+
+    // Check if source class is same as readData
+    assertEquals(srcModel, readData);
+
+    // Sanity check
+    readData._intField1--;
+    readData.intField2++;
+    assertNotSame(srcModel, readData);
+  }
+
+  protected ReadWriteTestModel prepareSampleModel() {
+    return ReadWriteTestModel.builder()
+        ._intField1(random.nextInt())
+        .intField2(random.nextInt())
+        .booleanField(random.nextFloat() < 0.5)
+        .stringField(orMaybeNull("string", Integer.toString(random.nextInt())))
+        .longField(Long.MAX_VALUE + random.nextInt())
+        .build();
+  }
+
+  /**
+   * Used to replace objet value with null, to check null serialization & deserialization.
+   */
+  protected <T> T orMaybeNull(String field, T t) {
+    Integer i = this.nullChecksMap.getOrDefault(field, 0);
+    this.nullChecksMap.put(field, ++i);
+    if (i % 2 == 0) {
+      return null;
+    } else {
+      return t;
+    }
+  }
+
+  @Json
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  private static class ReadWriteTestModel implements Cloneable {
+    @JsonProperty("intField1")
+    private int _intField1 = -1;
+
+    private int intField2 = -1;
+
+    private String stringField = "a";
+
+    private boolean booleanField;
+
+    private long longField;
+
+    @SneakyThrows
+    @Override
+    protected ReadWriteTestModel clone() {
+      return (ReadWriteTestModel) super.clone();
+    }
+  }
+}

--- a/tests/src/test/java/net/rsmogura/picoson/tests/ReadWriteTest.java
+++ b/tests/src/test/java/net/rsmogura/picoson/tests/ReadWriteTest.java
@@ -86,7 +86,7 @@ public class ReadWriteTest {
     // Check if source class is same as readData
     assertEquals(srcModel, readData);
 
-    // Sanity check
+    // Sanity check (what if equals got broken?)
     readData._intField1--;
     readData.intField2++;
     assertNotSame(srcModel, readData);

--- a/tests/src/test/java/net/rsmogura/picoson/tests/ReadWriteTest.java
+++ b/tests/src/test/java/net/rsmogura/picoson/tests/ReadWriteTest.java
@@ -31,7 +31,6 @@ import net.rsmogura.picoson.JsonReader;
 import net.rsmogura.picoson.JsonWriter;
 import net.rsmogura.picoson.annotations.Json;
 import net.rsmogura.picoson.annotations.JsonProperty;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**

--- a/tests/src/test/java/net/rsmogura/picoson/tests/SampleDataTest.java
+++ b/tests/src/test/java/net/rsmogura/picoson/tests/SampleDataTest.java
@@ -16,10 +16,13 @@
 package net.rsmogura.picoson.tests;
 
 import com.google.common.collect.ImmutableSet;
+import java.io.CharArrayWriter;
+import java.io.OutputStream;
 import java.util.HashSet;
 import java.util.Map.Entry;
 import java.util.Set;
 import net.rsmogura.picoson.JsonReader;
+import net.rsmogura.picoson.JsonWriter;
 import net.rsmogura.picoson.abi.JsonObjectDescriptor;
 import net.rsmogura.picoson.abi.JsonPropertyDescriptor;
 import net.rsmogura.picoson.abi.Names;
@@ -46,6 +49,17 @@ public class SampleDataTest {
         assertEquals("SHA256:123", read.getPasswordHash());
         assertEquals(true, read.isActive());
         assertEquals(826281, read.getType());
+    }
+
+    @Test
+    public void testWrite() throws Exception {
+        CharArrayWriter out = new CharArrayWriter();
+        JsonWriter writer = new JsonWriter(out);
+        SampleData sampleData = new SampleData();
+        sampleData.setUserName("user2");
+        sampleData.setType(-1);
+        sampleData.jsonWrite(writer);
+        writer.close();
     }
 
     @Test


### PR DESCRIPTION
The serialisation / write support for parser.

* Incorporate low-level JSON Writer;
* Create wrapper for JSON Writer;
* Refactor and generalise common code for reading and writing objects into `PropertyAbstractGenerator`
* Create `#jsonWrite` methods;
* Describe architecture in more details;
* Create simple read-write tests.